### PR TITLE
DnDしたファイルのタイプにapplication/zipを追加しました。

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
        * */
       const convertXsl = async (sourceFiles) => {
         const unCompressPromises = sourceFiles.map(async (file) => {
-          if (file.type === "application/x-zip-compressed") {
+          if (file.type.match(/^application\/(x-zip-compressed|zip)$/)) {
             return file.arrayBuffer().then(decompressZip);
           }
           return file;


### PR DESCRIPTION
大変便利なスクリプトを作成していただきまして、まことにありがとうございます。電子申請で発行された公文書のXMLとXSLを表示する方法を探していたところ、[こちら](https://zenn.dev/sora_kumo/articles/xsl-viewer-html)のHTML・JavaScriptを見つけましたので試したのですが、私の環境(macOS 15.4.1のSafariとGoogle Chrome 135.0.7049.115)ではZIPファイルのままでは電子公文書を表示できませんでした。

そこでJavaScriptをデバッグして、ファイルタイプが`application/x-zip-compressed`ではなく`application/zip`で渡されていることが分かりましたので、ファイルタイプが上記のいずれかにマッチする場合はZIPファイルとして判断するように処理を修正しました。

私の環境では[この修正版](https://yamakox.github.io/xsl-viewer-html/)で正常に表示できるようになりました。ご参考になれば幸いです。
