### PR TITLE
印刷対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
       .container {
         padding: 16px;
       }
+      .container > div {
+          /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 を表示する際に、コンテンツの中から div 要素全てに white-space: pre が指定されて、大きな余白が出る問題への対処。 */
+          white-space: normal;
+      }
       @media print {
         .container {
           padding: 0;

--- a/index.html
+++ b/index.html
@@ -16,12 +16,12 @@
         padding: 16px;
       }
       .container > div {
-          /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 を表示する際に、コンテンツの中から div 要素全てに white-space: pre が指定されて、大きな余白が出る問題への対処。 */
-          white-space: normal;
+        /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 を表示する際に、コンテンツの中から div 要素全てに white-space: pre が指定されて、大きな余白が出る問題への対処。 */
+        white-space: normal;
       }
       pre.oshirase {
-          /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 をMacのFirefox&Chromeで表示する際に「CSSを完全に理解」状態になる問題への対応。なぜかSafariはこれ無しで正しく動作する。*/
-          text-wrap-mode: wrap;
+        /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 をMacのFirefox&Chromeで表示する際に「CSSを完全に理解」状態になる問題への対応。なぜかSafariはこれ無しで正しく動作する。*/
+        text-wrap-mode: wrap;
       }
       @media print {
         .container {

--- a/index.html
+++ b/index.html
@@ -19,6 +19,10 @@
           /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 を表示する際に、コンテンツの中から div 要素全てに white-space: pre が指定されて、大きな余白が出る問題への対処。 */
           white-space: normal;
       }
+      pre.oshirase {
+          /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 をMacのFirefox&Chromeで表示する際に「CSSを完全に理解」状態になる問題への対応。なぜかSafariはこれ無しで正しく動作する。*/
+          text-wrap-mode: wrap;
+      }
       @media print {
         .container {
           padding: 0;

--- a/index.html
+++ b/index.html
@@ -12,6 +12,18 @@
         margin: 0;
         padding: 0;
       }
+      .container {
+        padding: 16px;
+      }
+      @media print {
+        .container {
+          padding: 0;
+        }
+        .container > h1,
+        .container > hr {
+            display: none;
+        }
+      }
     </style>
     <script>
       /**
@@ -137,7 +149,7 @@
             const contents = document.createElement("div");
             contents.innerHTML = doc;
             const div = document.createElement("div");
-            div.style.padding = "16px";
+            div.setAttribute("class", "container");
             const header = document.createElement("h1");
             header.innerText = name;
             const hr = document.createElement("hr");


### PR DESCRIPTION
今日このツールを見つけました！素晴らしいツールをありがとうございます。

年金事務所から送付された XML + XSLT を、ブラウザの印刷機能を介してPDF保管（＆関係各所に共有）しようとしたところ、以下の問題を検知したため、修正と対策を試みて、本 pull request としました。

- 本ツールで付加している情報が、印刷時も出力される
- 年金事務所の、少なくとも `健康保険・厚生年金保険被保険者標準報酬改定通知書` において、
    - 恐らく Windows + Edge では正しく描画されるけれどもMacでは崩れるようなCSS、と思われるものがある → 「CSSを完全に理解」の問題。
    - XML+XSLT 内部のCSS設定が、本ツールのHTML部分にも適用されてしまうことによる表示崩れ

邪魔でなければ取り込んで下さい🙇‍♀️

なお、 `XML+XSLT 内部のCSS設定が、本ツールのHTML部分にも適用されてしまうことによる表示崩れ` を回避するための方策として `iframe` 要素を用いた手法も試してみましたが、 XML+XSLT 内部に改ページ設定 `break-after: page;` のようなものがあった際に無視されるという問題に遭遇したため、諦めました。