### PR TITLE
保険料納入告知額・領収済額通知書 のMac対応（折り返し設定）

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
         /* 健康保険・厚生年金保険被保険者標準報酬改定通知書 をMacのFirefox&Chromeで表示する際に「CSSを完全に理解」状態になる問題への対応。なぜかSafariはこれ無しで正しく動作する。*/
         text-wrap-mode: wrap;
       }
+      pre.normal {
+        /* 保険料納入告知額・領収済額通知書 をMacで表示した場合のレイアウト崩れ対応。 */
+        text-wrap: auto;
+      }
       @media print {
         .container {
           padding: 0;


### PR DESCRIPTION
年金機構の「保険料納入告知額・領収済額通知書」をMacで描画させた際に、折り返されるべきテキストが折り返されていなかったので、折り返すようにCSSを仕込みました。

## レイアウト崩れの原因
恐らく、IEでは `<pre>` はデフォルトで折り返しているのではないかと（推測）。だから年金機構のXSLTでのCSS設定が甘い説。

## 本PRの登録時の状態
draft PR として作成した状態では、以下の確認が取れていません。確認取れたら正式なPRとして更新します。

- 本件の修正が、他の文書のレイアウトを壊していないこと、の確認（本システムで開くのは年金機構由来のものばかりでしょうから年金機構のものがテスト対象）
- 本件の修正が、Windows上のChromeでのレイアウトを壊していないこと、の確認（公式のIEを使った方法で開けない状態が続いているみたいで、本システムのWindowsユーザも増えてそうだから一応…）

※いま手元にWindowsマシンが無いので…😅

## 補足
https://shinsei.e-gov.go.jp/contents/news/2025-10-08t1341530900_1662.html
2026年1月23日時点でのニュースで、e-Gov 内で各種文書のプレビューができるようにする予定である、という告知が出ています。これが「使い物になる」レベルの仕上がりだったら、本システムの利用機会は減ってしまうかも、ですね。